### PR TITLE
Change trino-ci to adapt JDK17

### DIFF
--- a/.github/workflows/trino-ci.yml
+++ b/.github/workflows/trino-ci.yml
@@ -29,10 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: maven
       - name: Install dependency with Maven


### PR DESCRIPTION

## Why are the changes needed?
Trino needs JDK17 so change the CI's JDK version to 17.

## Brief change log

  - *Change trino-ci.yml java version to 17.*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
