### PR TITLE
Change table scan doesn't support SplitSize, so filter it.

### DIFF
--- a/trino/src/main/java/com/netease/arctic/trino/unkeyed/IcebergSplitSource.java
+++ b/trino/src/main/java/com/netease/arctic/trino/unkeyed/IcebergSplitSource.java
@@ -28,6 +28,7 @@ import com.google.common.io.Closer;
 import com.netease.arctic.data.DataFileType;
 import com.netease.arctic.data.PrimaryKeyedFile;
 import com.netease.arctic.scan.ArcticFileScanTask;
+import com.netease.arctic.scan.ChangeTableIncrementalScan;
 import com.netease.arctic.trino.delete.TrinoDeleteFile;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
@@ -207,7 +208,11 @@ public class IcebergSplitSource
       if (requiresColumnStats) {
         scan = scan.includeColumnStats();
       }
-      this.fileScanTaskIterable = TableScanUtil.splitFiles(scan.planFiles(), tableScan.targetSplitSize());
+      if (tableScan instanceof ChangeTableIncrementalScan) {
+        this.fileScanTaskIterable = scan.planFiles();
+      } else {
+        this.fileScanTaskIterable = TableScanUtil.splitFiles(scan.planFiles(), tableScan.targetSplitSize());
+      }
       closer.register(fileScanTaskIterable);
       this.fileScanTaskIterator = fileScanTaskIterable.iterator();
       closer.register(fileScanTaskIterator);


### PR DESCRIPTION

## Why are the changes needed?
Change table scan doesn't support SplitSize, so we should filter it.

## Brief change log

  - *Do not use split size in the change table scan.*
  - 
## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
