### PR TITLE
Fix jacoco-maven-plugin report EOFException

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -48,7 +48,7 @@ jobs:
           cache: maven
 
       - name: Build all module with Maven
-        run: mvn install -pl '!trino'
+        run: mvn clean install -pl '!trino'
 
       - name: Code coverage
         uses: codecov/codecov-action@v3

--- a/.github/workflows/trino-ci.yml
+++ b/.github/workflows/trino-ci.yml
@@ -47,10 +47,10 @@ jobs:
           cache: maven
 
       - name: Install dependency with Maven
-        run: mvn install -DskipTests -pl 'ams/ams-api,core,hive' -am
+        run: mvn clean install -DskipTests -pl 'ams/ams-api,core,hive' -am
 
       - name: Build with Maven
-        run: mvn test -pl 'trino'
+        run: mvn clean test -pl 'trino'
 
       - name: Code coverage
         uses: codecov/codecov-action@v3

--- a/pom.xml
+++ b/pom.xml
@@ -446,6 +446,11 @@
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
                     <version>${maven-jacoco-plugin.version}</version>
+                    <configuration>
+                        <includes>
+                            <include>**/*.class</include>
+                        </includes>
+                    </configuration>
                     <executions>
                         <execution>
                             <id>pre-test</id>


### PR DESCRIPTION

## Why are the changes needed?

The following error is encountered when CI is run, which should be fixed:
`Failed to execute goal org.jacoco:jacoco-maven-plugin:0.8.7:report (report) on project arctic-flink-1.14: An error has occurred in JaCoCo report generation.: Error while creating report: null: EOFException -> [Help 1].`

## Brief change log

  - *clean before install and include only .class files in plugin configuration*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
